### PR TITLE
If light and dark theme have the same name, use color_scheme

### DIFF
--- a/toggle_dark_mode.py
+++ b/toggle_dark_mode.py
@@ -6,14 +6,20 @@ class ToggleDarkModeCommand(sublime_plugin.TextCommand):
     try:
       ui_info = sublime.ui_info()
       current_theme = ui_info.get("theme").get("value")
+      current_color_scheme = ui_info.get("color_scheme").get("value")
       prefer_light = ui_info.get("system").get("style") == 'light'
     except KeyError:
       current_theme = "auto"
       prefer_light = False
 
     settings = sublime.load_settings("Preferences.sublime-settings")
-    is_light = (current_theme == "auto" and prefer_light) or current_theme == settings.get("light_theme")
 
+    # Light theme and dark theme might have the same name, use color scheme to get current state:
+    if settings.get("light_theme") == settings.get("dark_theme"):
+      is_light = (current_theme == "auto" and prefer_light) or current_color_scheme == settings.get("light_color_scheme")
+    else:
+      is_light = (current_theme == "auto" and prefer_light) or current_theme == settings.get("light_theme")
+    
     self._set_dark_mode(settings, not is_light, prefer_light)
 
   def _set_dark_mode(self, settings, is_light, prefer_light):


### PR DESCRIPTION
If `theme` has the same value for light and dark theme variants, the switching does not work because the current state cannot be determined. This PR adds a check for coinciding names and then derives the current state from the `color_scheme` variable instead.

If those are also the same, we don't have to switch anyway. :)

This fixes #2 